### PR TITLE
Improve player physics, add leaderboard

### DIFF
--- a/client/src/game/renderer.ts
+++ b/client/src/game/renderer.ts
@@ -37,7 +37,7 @@ export function renderGame(state: AppState, ping: GamePing) {
         y: GAME_HEIGHT - 20,
         font: "27px Arial",
     });
-    renderLeaderboard(context, ping.players); 
+    renderLeaderboard(context, ping.players);
     renderButtons(context, buttons);
     renderMetadata(state);
 }

--- a/client/src/game/renderer.ts
+++ b/client/src/game/renderer.ts
@@ -15,6 +15,7 @@ const RED_HEX = "#ff0000";
 
 const PLATFORM_HEIGHT = 30;
 const PLATFORM_COLOR = "green";
+const LEADERBOARD_LINE_HEIGHT = 35;
 
 /**
  * Does NOT mutate the app state.
@@ -33,10 +34,10 @@ export function renderGame(state: AppState, ping: GamePing) {
     renderLabel(context, {
         text: `Time: ${ping.serverAge}`,
         x: 10,
-        y: 20,
-        font: "30px Arial",
-
+        y: GAME_HEIGHT - 20,
+        font: "27px Arial",
     });
+    renderLeaderboard(context, ping.players); 
     renderButtons(context, buttons);
     renderMetadata(state);
 }
@@ -74,6 +75,27 @@ export function renderMetadata(state: AppState) {
     });
 }
 
+function renderLeaderboard(context: Context2D, players: PlayerState[]) {
+    const sortedPlayers = [...players].sort((a, b) => b.score - a.score);
+
+    renderLabel(context, {
+        text: "Leaderboard",
+        x: 10,
+        y: LEADERBOARD_LINE_HEIGHT,
+        font: "25px Arial",
+    });
+    for (let i = 1; i <= sortedPlayers.length; i++) {
+        const player = sortedPlayers[i - 1];
+        renderLabel(context, {
+            text: `${i}. ${player.name} | ${player.score}`,
+            x: 10,
+            y: LEADERBOARD_LINE_HEIGHT + (i * LEADERBOARD_LINE_HEIGHT),
+            font: "bold 27px Arial",
+            color: player.color,
+        });
+    }
+}
+
 function renderPlatform(context: Context2D, platform: GamePlatform) {
     const { x, y, width } = platform;
     if (x > GAME_WIDTH || y > GAME_HEIGHT) {
@@ -92,7 +114,7 @@ function renderPlayer(context: Context2D, player: PlayerState) {
         return;
     }
     renderLabel(context, {
-        text: `${player.name}: ${player.score}`,
+        text: player.name,
         x: player.x + (PLAYER_WIDTH / 2),
         y: player.y - 15,
         color: player.color,

--- a/client/src/game/renderer.ts
+++ b/client/src/game/renderer.ts
@@ -1,5 +1,5 @@
 import { Context2D } from "../canvas/types";
-import { GameUpdate } from "./types/messages";
+import { GamePing } from "./types/messages";
 import { GamePlatform, PlayerState } from "./types/models";
 import { renderButtons } from "../canvas/button";
 import { renderLabel } from "../canvas/label";
@@ -22,16 +22,16 @@ const PLATFORM_COLOR = "green";
  * Renders the game to the canvas based on the current app state
  * and game update passed in.
  * @param state app state including the context to draw to
- * @param game game state received from the server
+ * @param ping game state received from the server
  */
-export function renderGame(state: AppState, game: GameUpdate) {
+export function renderGame(state: AppState, ping: GamePing) {
     const { context, buttons } = state;
 
     clearCanvas(context);
-    game.platforms.forEach(platform => renderPlatform(context, platform));
-    game.players.forEach(player => renderPlayer(context, player));
+    ping.platforms.forEach(platform => renderPlatform(context, platform));
+    ping.players.forEach(player => renderPlayer(context, player));
     renderLabel(context, {
-        text: `Time: ${game.serverAge}`,
+        text: `Time: ${ping.serverAge}`,
         x: 10,
         y: 20,
         font: "30px Arial",

--- a/client/src/game/types/messages.ts
+++ b/client/src/game/types/messages.ts
@@ -1,45 +1,58 @@
+/**
+ * Type definitions for messages sent over the network.
+ * A message is one of the following types:
+ *
+ * - Ping: from server to client, send at a fixed interval
+ * - Event: can be sent both ways, triggered by some event
+ * - Reply: optional response to an event
+ */
+
 import { GamePlatform, PlayerControl, PlayerState } from "./models";
 
 export type SocketMessage =
-    | GameUpdate
-    | GameJoinUpdate
-    | GameOverUpdate
-    | PlayerControlUpdate
-    | PlayerJoinUpdate
-    | ServerError
+    | GamePing
+    | ControlChangeEvent
+    | JoinEvent
+    | GameOverEvent
+    | ErrorReply
 ;
 
-export type GameUpdate = {
-    type: "gameUpdate";
+
+// PINGS
+
+export type GamePing = {
+    type: "GamePing";
     serverAge: number;
     players: PlayerState[];
     platforms: GamePlatform[];
 };
 
-export type GameJoinUpdate = {
-    type: "gameJoinUpdate";
-    playerId: string;
-    serverAge: number;
-    players: PlayerState[];
-    platforms: GamePlatform[];
-};
 
-export type GameOverUpdate = {
-    type: "gameOverUpdate";
-    reason: string;
-};
+// EVENTS
 
-export type PlayerControlUpdate = {
-    type: "playerControlUpdate";
+/** client to server */
+export type ControlChangeEvent = {
+    type: "ControlChangeEvent";
     pressedControls: PlayerControl[];
 };
 
-export type PlayerJoinUpdate = {
-    type: "playerJoinUpdate";
+/** client to server */
+export type JoinEvent = {
+    type: "JoinEvent";
     name: string;
 }
 
-export type ServerError = {
-    type: "serverError";
+/** server to client */
+export type GameOverEvent = {
+    type: "GameOverEvent";
+    reason: string;
+};
+
+
+// REPLIES
+
+/** server to client */
+export type ErrorReply = {
+    type: "ErrorReply";
     message: string;
 };

--- a/server/src/main/java/io/github/aggarcia/game/GameLoop.java
+++ b/server/src/main/java/io/github/aggarcia/game/GameLoop.java
@@ -123,6 +123,7 @@ public class GameLoop {
         Collection<Player> players,
         Collection<WebSocketSession> sessions
     ) {
+        // TODO: add time limit of one hour to game loop
         int serverAge = 0;  // in seconds
         int tickCount = 0;
         List<GamePlatform> platforms = new ArrayList<>();
@@ -142,7 +143,7 @@ public class GameLoop {
                 serverAge++;
             }
             if (response.isUpdateNeeded()) try {
-                var update = GameUpdate.fromGameState(
+                var update = GamePing.fromGameState(
                     players,
                     platforms,
                     serverAge

--- a/server/src/main/java/io/github/aggarcia/game/GamePing.java
+++ b/server/src/main/java/io/github/aggarcia/game/GamePing.java
@@ -8,22 +8,20 @@ import io.github.aggarcia.players.Player;
 import io.github.aggarcia.players.PlayerState;
 import io.github.aggarcia.shared.SocketMessage;
 
-public record GameUpdate(
-    /** Should always be GAME_UPDATE */
-    SocketMessage type,
+public record GamePing(
     int serverAge,
     List<PlayerState> players,
     List<GamePlatform> platforms
-) {
+) implements SocketMessage {
     /**
-     * Factory function to create a game update message based on
+     * Factory function to create a game ping message based on
      * the current state of the game.
      * @param players list of players in the game
      * @param serverAge age in seconds since the game started
-     * @return new instance of GameUpdate
+     * @return new instance of GamePing
      */
     public static
-    GameUpdate fromGameState(
+    GamePing fromGameState(
         Collection<Player> players,
         Collection<GamePlatform> platforms,
         int serverAge
@@ -33,8 +31,7 @@ public record GameUpdate(
             .map(player -> player.toPlayerState())
             .toList();
 
-        return new GameUpdate(
-            SocketMessage.GAME_UPDATE,
+        return new GamePing(
             serverAge,
             playersState,
             platforms.stream().toList()

--- a/server/src/main/java/io/github/aggarcia/players/PlayerEventHandler.java
+++ b/server/src/main/java/io/github/aggarcia/players/PlayerEventHandler.java
@@ -114,6 +114,7 @@ public final class PlayerEventHandler {
         JoinEvent event,
         Map<String, Player> sessions
     ) {
+        // TODO: put limit on player count
         if (sessions.containsKey(client)) {
             // client already has a player
             return new CreatePlayer(true, null, null);

--- a/server/src/main/java/io/github/aggarcia/players/events/ControlChangeEvent.java
+++ b/server/src/main/java/io/github/aggarcia/players/events/ControlChangeEvent.java
@@ -5,8 +5,6 @@ import java.util.List;
 import io.github.aggarcia.players.PlayerControl;
 import io.github.aggarcia.shared.SocketMessage;
 
-public record PlayerControlUpdate(
-    SocketMessage type,
+public record ControlChangeEvent(
     List<PlayerControl> pressedControls
-) {}
-
+) implements SocketMessage {}

--- a/server/src/main/java/io/github/aggarcia/players/events/JoinEvent.java
+++ b/server/src/main/java/io/github/aggarcia/players/events/JoinEvent.java
@@ -2,7 +2,6 @@ package io.github.aggarcia.players.events;
 
 import io.github.aggarcia.shared.SocketMessage;
 
-public record PlayerJoinUpdate(
-    SocketMessage type,
+public record JoinEvent(
     String name
-) {}
+) implements SocketMessage {}

--- a/server/src/main/java/io/github/aggarcia/shared/SocketMessage.java
+++ b/server/src/main/java/io/github/aggarcia/shared/SocketMessage.java
@@ -1,18 +1,32 @@
 package io.github.aggarcia.shared;
 
-import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
-public enum SocketMessage {
-    GAME_UPDATE("gameUpdate"),
-    GAME_OVER_UPDATE("gameOverUpdate"),
-    PLAYER_CONTROL_UPDATE("playerControlUpdate"),
-    PLAYER_JOIN_UPDATE("playerJoinUpdate"),
-    SERVER_ERROR("serverError");
+import io.github.aggarcia.game.GamePing;
+import io.github.aggarcia.players.events.ControlChangeEvent;
+import io.github.aggarcia.players.events.JoinEvent;
 
-    @JsonValue
-    public final String jsonValue;
-
-    SocketMessage(String value) {
-        this.jsonValue = value;
-    }
-}
+/**
+ * Base class for all event, reply, and ping messages.
+ * Subclasses automatically include type information for polymorphic
+ * serialization and deserialization.
+ * 
+ * IMPORTANT: to add new messages, make sure to add a @JsonSubTypes.Type
+ * declaration below so that Jackson can use the name to serialize/deserialize
+ * the message as JSON
+ */
+@JsonTypeInfo(
+    use=Id.NAME,
+    include=As.PROPERTY,
+    property="type"
+)
+@JsonSubTypes({
+    @JsonSubTypes.Type(
+        value = ControlChangeEvent.class, name = "ControlChangeEvent"),
+    @JsonSubTypes.Type(value = GamePing.class, name = "GamePing"),
+    @JsonSubTypes.Type(value = JoinEvent.class, name = "JoinEvent")
+})
+public interface SocketMessage {}

--- a/server/src/main/java/io/github/aggarcia/shared/SocketMessage.java
+++ b/server/src/main/java/io/github/aggarcia/shared/SocketMessage.java
@@ -13,7 +13,7 @@ import io.github.aggarcia.players.events.JoinEvent;
  * Base class for all event, reply, and ping messages.
  * Subclasses automatically include type information for polymorphic
  * serialization and deserialization.
- * 
+ *
  * IMPORTANT: to add new messages, make sure to add a @JsonSubTypes.Type
  * declaration below so that Jackson can use the name to serialize/deserialize
  * the message as JSON

--- a/server/src/test/java/io/github/aggarcia/players/PlayerEventHandlerTest.java
+++ b/server/src/test/java/io/github/aggarcia/players/PlayerEventHandlerTest.java
@@ -17,12 +17,11 @@ import org.springframework.web.socket.TextMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.github.aggarcia.players.events.PlayerControlUpdate;
-import io.github.aggarcia.players.events.PlayerJoinUpdate;
+import io.github.aggarcia.players.events.ControlChangeEvent;
+import io.github.aggarcia.players.events.JoinEvent;
 import io.github.aggarcia.players.updates.CreatePlayer;
 import io.github.aggarcia.players.updates.ErrorUpdate;
 import io.github.aggarcia.players.updates.UpdateVelocity;
-import io.github.aggarcia.shared.SocketMessage;
 
 public class PlayerEventHandlerTest {
     @Test
@@ -34,18 +33,9 @@ public class PlayerEventHandlerTest {
     }
 
     @Test
-    void test_processEvent_missingType_throwsExecption() {
-        var message = new TextMessage("{}");
-        assertThrows(IllegalArgumentException.class, () -> {
-            PlayerEventHandler
-                .processEvent("", message, Collections.emptyMap());
-        });
-    }
-
-    @Test
     void test_processEvent_badType_throwsException() throws Exception {
         var message = new TextMessage("{\"type\":\"bad type\"}");
-        assertThrows(IllegalArgumentException.class, () -> {
+        assertThrows(JsonProcessingException.class, () -> {
             PlayerEventHandler
                 .processEvent("", message, Collections.emptyMap());
         });
@@ -54,7 +44,7 @@ public class PlayerEventHandlerTest {
     @Test
     void test_processEvent_playerJoinUpdate_returnsName()
     throws Exception {
-        var payload = new PlayerJoinUpdate(SocketMessage.PLAYER_JOIN_UPDATE, "testName");
+        var payload = new JoinEvent("testName");
         var message = new TextMessage(new ObjectMapper().writeValueAsString(payload));
 
         CreatePlayer result = (CreatePlayer) PlayerEventHandler
@@ -69,86 +59,85 @@ public class PlayerEventHandlerTest {
     @Test
     void test_processEvent_playerControlUpdate_callsProcessControlUpdate()
     throws Exception {
-        var message = controlListAsMessage(Collections.emptyList());
+        var event = new ControlChangeEvent(Collections.emptyList());
+        var message = serialize(event);
         assertEquals(
             PlayerEventHandler
-                .processControlUpdate("client1", message, Collections.emptyMap()),
+                .processControlChange("client1", event, Collections.emptyMap()),
             PlayerEventHandler
                 .processEvent("client1", message, Collections.emptyMap())
         );
     }
 
     @Test
-    void test_processControlUpdate_missingPlayer_returnsError() throws Exception {
-        var message = controlListAsMessage(Collections.emptyList());
+    void test_processControlChange_missingPlayer_returnsError() throws Exception {
+        var event = new ControlChangeEvent(Collections.emptyList());
         // client id "test client" doesnt exist in the sessions (empty map)
-        var result = (ErrorUpdate) PlayerEventHandler.processControlUpdate(
+        var result = (ErrorUpdate) PlayerEventHandler.processControlChange(
             "test client",
-            message,
+            event,
             new HashMap<>()
         );
         assertTrue(result instanceof ErrorUpdate);
     }
 
     @Test
-    void test_processControlUpdate_noControls_returnsZeroVelocity() throws Exception {
-        var message = controlListAsMessage(Collections.emptyList());
-        var velocity = processControlWithValidPlayer(message);
+    void test_processControlChange_noControls_returnsZeroVelocity() throws Exception {
+        var event = new ControlChangeEvent(Collections.emptyList());
+        var velocity = processControlWithValidPlayer(event);
         assertEquals(0, velocity.xVelocity());
         assertEquals(0, velocity.yVelocity());
     }
 
     @Test
-    void test_processControlUpdate_rightControl_returnsPositiveX() throws Exception {
-        var message = controlListAsMessage(List.of(PlayerControl.RIGHT));
-        var velocity = processControlWithValidPlayer(message);
+    void test_processControlChange_rightControl_returnsPositiveX() throws Exception {
+        var event = new ControlChangeEvent(List.of(PlayerControl.RIGHT));
+        var velocity = processControlWithValidPlayer(event);
         assertTrue(velocity.xVelocity() > 0);
         assertEquals(0, velocity.yVelocity());
     }
 
     @Test
-    void test_processControlUpdate_leftControl_returnsNegativeX() throws Exception {
-        var message = controlListAsMessage(List.of(PlayerControl.LEFT));
-        var velocity = processControlWithValidPlayer(message);
+    void test_processControlChange_leftControl_returnsNegativeX() throws Exception {
+        var event = new ControlChangeEvent(List.of(PlayerControl.LEFT));
+        var velocity = processControlWithValidPlayer(event);
         assertTrue(velocity.xVelocity() < 0);
         assertEquals(0, velocity.yVelocity());
     }
 
     @Test
-    void test_processControlUpdate_downControl_returnsZero() throws Exception {
-        var message = controlListAsMessage(List.of(PlayerControl.DOWN));
-        var velocity = processControlWithValidPlayer(message);
+    void test_processControlChange_downControl_returnsZero() throws Exception {
+        var event = new ControlChangeEvent(List.of(PlayerControl.DOWN));
+        var velocity = processControlWithValidPlayer(event);
         assertEquals(0, velocity.xVelocity());
         assertEquals(0, velocity.yVelocity());
     }
 
     @Test
-    void test_processControlUpdate_upControl_returnsNegativeY() throws Exception {
-        var message = controlListAsMessage(List.of(PlayerControl.UP));
-        var velocity = processControlWithValidPlayer(message);
+    void test_processControlChange_upControl_returnsNegativeY() throws Exception {
+        var event = new ControlChangeEvent(List.of(PlayerControl.UP));
+        var velocity = processControlWithValidPlayer(event);
         assertEquals(0, velocity.xVelocity());
         assertTrue(velocity.yVelocity() < 0);
     }
 
     @Test
     void
-    test_processControlUpdate_multipleControls_returnsCorrectVelocity()
+    test_processControlChange_multipleControls_returnsCorrectVelocity()
     throws Exception {
         var controls =
             List.of(PlayerControl.LEFT, PlayerControl.DOWN, PlayerControl.LEFT);
-        var message = controlListAsMessage(controls);
-        var velocity = processControlWithValidPlayer(message);
+        var event = new ControlChangeEvent(controls);
+        var velocity = processControlWithValidPlayer(event);
         assertTrue(velocity.xVelocity() < 0);
         assertEquals(0, velocity.yVelocity());
     }
 
-    private TextMessage controlListAsMessage(List<PlayerControl> pressedControls) {
+    // TODO: tests for processJoin
+
+    private <T> TextMessage serialize(T data) {
         try {
-            var update = new PlayerControlUpdate(
-                SocketMessage.PLAYER_CONTROL_UPDATE,
-                pressedControls
-            );
-            return new TextMessage(new ObjectMapper().writeValueAsString(update));
+            return new TextMessage(new ObjectMapper().writeValueAsString(data));
         } catch (JsonProcessingException e) {
             fail(e);
             return null;  // to make the compiler happy
@@ -156,12 +145,12 @@ public class PlayerEventHandlerTest {
     }
 
     /**
-     * Wrapper for calling processControlUpdate with a valid player session
+     * Wrapper for calling processControlChange with a valid player session
      */
     private UpdateVelocity
-    processControlWithValidPlayer(TextMessage event)throws Exception {
+    processControlWithValidPlayer(ControlChangeEvent event)throws Exception {
         var players = Map.of("client1", Player.createRandomPlayer("player1"));
         return (UpdateVelocity) PlayerEventHandler
-            .processControlUpdate("client1", event, players);
+            .processControlChange("client1", event, players);
     }
 }


### PR DESCRIPTION
- Refactor message handling to include more context about previous game state and simplify polymorphism for future extension while staying purely functional
- Consider previous player velocity when computing the new one on event processing, for more realistic physics
- Add a leaderboard showing the score of each player, sorted